### PR TITLE
Add task dag format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,23 @@ The following options are available:
 
 `prov.enabled`
 
-Create the provenance manifest (default: `true` if plugin is loaded).
+Create the provenance report (default: `true` if plugin is loaded).
 
 `prov.file`
 
-The path of the provenance manifest (default: `manifest.json`).
+The path of the provenance report (default: `manifest.json`).
 
 `prov.format`
 
-The manifest format. Can be `legacy` or `bco` (default: `legacy`).
+The report format. The following formats are available:
 
-*Note: The BCO format is experimental and may change in future releases. Visit the [BCO User Guide](https://docs.biocomputeobject.org/user_guide/) to learn more about this format and how to extend it with information that isn't available to Nextflow.*
+- `bco`: Render a [BioCompute Object](https://biocomputeobject.org/).
+
+  Visit the [BCO User Guide](https://docs.biocomputeobject.org/user_guide/) to learn more about this format and how to extend it with information that isn't available to Nextflow.
+
+- `dag`: Render the task graph as a Mermaid diagram embedded in an HTML document.
+
+- `legacy`: Render the legacy format originally defined in this plugin (default).
 
 `prov.overwrite`
 
@@ -46,7 +52,7 @@ Overwrite any existing provenance report with the same name (default: `false`).
 
 `prov.patterns`
 
-List of file patterns to include in the provenance manifest, from the set of published files. By default, all published files are included.
+List of file patterns to include in the provenance report, from the set of published files. By default, all published files are included.
 
 ## Development
 

--- a/plugins/nf-prov/src/main/nextflow/prov/DagRenderer.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/DagRenderer.groovy
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.prov
+
+import java.nio.file.Path
+
+import groovy.transform.CompileStatic
+import groovy.transform.TupleConstructor
+import nextflow.Session
+import nextflow.processor.TaskRun
+import nextflow.script.WorkflowMetadata
+import nextflow.util.StringUtils
+
+/**
+ * Renderer for the task graph format.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@CompileStatic
+class DagRenderer implements Renderer {
+
+    @Delegate
+    private PathNormalizer normalizer
+
+    @Override
+    void render(Session session, Set<TaskRun> tasks, Map<Path,Path> workflowOutputs, Path path) {
+        // get workflow metadata
+        final metadata = session.workflowMetadata
+        this.normalizer = new PathNormalizer(metadata)
+
+        // get workflow inputs
+        final taskLookup = ProvHelper.getTaskLookup(tasks)
+        final workflowInputs = ProvHelper.getWorkflowInputs(tasks, taskLookup)
+
+        // construct task graph
+        final dag = new Dag(getVertices(tasks), taskLookup)
+
+        path.text = renderHtml(dag)
+    }
+
+    private Map<TaskRun,Vertex> getVertices(Set<TaskRun> tasks) {
+        def result = [:]
+        for( def task : tasks ) {
+            final inputs = task.getInputFilesMap()
+            final outputs = ProvHelper.getTaskOutputs(task)
+
+            result[task] = new Vertex(result.size(), task.name, inputs, outputs)
+        }
+
+        return result
+    }
+
+    /**
+     * Render the task graph as a Mermaid diagram embedded
+     * in an HTML document.
+     *
+     * @param dag
+     */
+    private String renderHtml(Dag dag) {
+        // load html template
+        final writer = new StringWriter()
+        final res = DagRenderer.class.getResourceAsStream('mermaid.dag.template.html')
+        int ch
+        while( (ch=res.read()) != -1 ) {
+            writer.append(ch as char)
+        }
+        final template = writer.toString()
+
+        // render html document
+        final mmd = renderDiagram(dag)
+        return template.replace('REPLACE_WITH_NETWORK_DATA', mmd)
+    }
+
+    /**
+     * Render the task graph as a Mermaid diagram.
+     *
+     * @param dag
+     */
+    private String renderDiagram(Dag dag) {
+        // construct task tree
+        final taskTree = getTaskTree(dag.vertices)
+
+        // render diagram
+        def lines = [] as List<String>
+        lines << "flowchart TD"
+
+        // render workflow inputs
+        final inputs = [:] as Map<Path,String>
+
+        lines << "    subgraph \" \""
+
+        dag.vertices.each { task, vertex ->
+            vertex.inputs.each { name, path ->
+                if( dag.getProducerVertex(path) || path in inputs )
+                    return
+
+                inputs[path] = "in${inputs.size()}".toString()
+                lines << "    ${inputs[path]}[\"${path.name}\"]".toString()
+
+                // add hyperlink if path is remote URL
+                final sourcePath = normalizePath(path)
+                if( isRemotePath(sourcePath) )
+                    lines << "    click ${inputs[path]} href \"${sourcePath}\" _blank".toString()
+            }
+        }
+
+        lines << "    end"
+
+        // render tasks
+        renderTaskTree(lines, null, taskTree)
+
+        // render task inputs
+        final taskOutputs = [] as Set<Path>
+
+        dag.vertices.each { task, vertex ->
+            vertex.inputs.each { name, path ->
+                // render task input from predecessor task
+                final pred = dag.getProducerVertex(path)
+                if( pred != null ) {
+                    lines << "    ${pred.name} -->|${path.name}| ${vertex.name}".toString()
+                    taskOutputs << path
+                }
+
+                // render task input from workflow input
+                else {
+                    lines << "    ${inputs[path]} --> ${vertex.name}".toString()
+                }
+            }
+        }
+
+        // render task outputs
+        final outputs = [:] as Map<Path,String>
+
+        dag.vertices.each { task, vertex ->
+            vertex.outputs.each { path ->
+                if( path in taskOutputs || path in outputs )
+                    return
+
+                outputs[path] = "out${outputs.size()}".toString()
+                lines << "    ${vertex.name} --> ${outputs[path]}".toString()
+            }
+        }
+
+        // render workflow outputs
+        lines << "    subgraph \" \""
+
+        outputs.each { path, label ->
+            lines << "    ${label}[${path.name}]".toString()
+        }
+
+        lines << "    end"
+
+        return lines.join('\n')
+    }
+
+    /**
+     * Construct a task tree with a subgraph for each subworkflow.
+     *
+     * @param vertices
+     */
+    private Map getTaskTree(Map<TaskRun,Vertex> vertices) {
+        def taskTree = [:]
+
+        for( def entry : vertices ) {
+            def task = entry.key
+            def vertex = entry.value
+
+            // infer subgraph keys from fully qualified process name
+            final result = getSubgraphKeys(task.processor.name)
+            final keys = (List)result[0]
+
+            // update vertex label
+            final hash = task.hash.toString()
+            vertex.label = task.name.replace(task.processor.name, (String)result[1])
+
+            // navigate to given subgraph
+            def subgraph = taskTree
+            for( def key : keys ) {
+                if( key !in subgraph )
+                    subgraph[key] = [:]
+                subgraph = subgraph[key]
+            }
+
+            // add vertex to tree
+            subgraph[vertex.name] = vertex
+        }
+
+        return taskTree
+    }
+
+    /**
+     * Get the subgraph keys from a fully qualified process name.
+     *
+     * @param name
+     */
+    private List getSubgraphKeys(String name) {
+        final tokens = name.tokenize(':')
+        return [
+            tokens[0..<tokens.size()-1],
+            tokens.last()
+        ]
+    }
+
+    private boolean isRemotePath(String path) {
+        if( !path ) return false
+        final result = StringUtils.getUrlProtocol(path)
+        return result != null && result != 'file'
+    }
+
+    /**
+     * Render a tree of tasks and subgraphs.
+     *
+     * @param lines
+     * @param name
+     * @param taskTree
+     */
+    private void renderTaskTree(List<String> lines, String name, Map<String,Object> taskTree) {
+        if( name )
+            lines << "    subgraph ${name}".toString()
+
+        taskTree.each { key, value ->
+            if( value instanceof Map )
+                renderTaskTree(lines, key, value)
+            else if( value instanceof Vertex )
+                lines << "    ${renderTask(value)}".toString()
+        }
+
+        if( name )
+            lines << "    end"
+    }
+
+    private String renderTask(Vertex vertex) {
+        return "${vertex.name}([\"${vertex.label}\"])"
+    }
+
+    @TupleConstructor
+    static class Dag {
+        Map<TaskRun,Vertex> vertices
+        Map<Path,TaskRun> taskLookup
+
+        Vertex getProducerVertex(Path path) {
+            vertices[taskLookup[path]]
+        }
+    }
+
+    @TupleConstructor
+    static class Vertex {
+        int index
+        String label
+        Map<String,Path> inputs
+        List<Path> outputs
+
+        String getName() { "t${index}" }
+
+        @Override
+        String toString() { label }
+    }
+
+}

--- a/plugins/nf-prov/src/main/nextflow/prov/PathNormalizer.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/PathNormalizer.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.prov
+
+import java.nio.file.Path
+
+import groovy.transform.CompileStatic
+import nextflow.script.WorkflowMetadata
+
+/**
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@CompileStatic
+class PathNormalizer {
+
+    private URL repository
+
+    private String commitId
+
+    private String launchDir
+
+    private String projectDir
+
+    private String workDir
+
+    PathNormalizer(WorkflowMetadata metadata) {
+        repository = metadata.repository ? new URL(metadata.repository) : null
+        commitId = metadata.commitId
+        projectDir = metadata.projectDir.toUriString()
+        launchDir = metadata.launchDir.toUriString()
+        workDir = metadata.workDir.toUriString()
+    }
+
+    /**
+     * Normalize paths so that local absolute paths become
+     * relative paths, and local paths derived from remote URLs
+     * become the URLs.
+     *
+     * @param path
+     */
+    String normalizePath(Path path) {
+        normalizePath(path.toUriString())
+    }
+
+    String normalizePath(String path) {
+        // replace work directory with relative path
+        if( path.startsWith(workDir) )
+            return path.replace(workDir, 'work')
+
+        // replace project directory with source URL (if applicable)
+        if( repository && path.startsWith(projectDir) )
+            return getProjectSourceUrl(path)
+
+        // replace launch directory with relative path
+        if( path.startsWith(launchDir) )
+            return path.replace(launchDir + '/', '')
+
+        return path
+    }
+
+    /**
+     * Get the source URL for a project asset.
+     *
+     * @param path
+     */
+    private String getProjectSourceUrl(String path) {
+        // TODO: add other git providers
+        if( repository.host == 'github.com' )
+            return path.replace(projectDir, "${repository}/tree/${commitId}")
+        else
+            return path
+    }
+
+}

--- a/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/ProvObserver.groovy
@@ -42,7 +42,7 @@ class ProvObserver implements TraceObserver {
 
     public static final String DEF_FILE_NAME = 'manifest.json'
 
-    public static final List<String> VALID_FORMATS = ['legacy', 'bco']
+    public static final List<String> VALID_FORMATS = ['bco', 'dag', 'legacy']
 
     private Session session
 
@@ -56,7 +56,7 @@ class ProvObserver implements TraceObserver {
 
     private Set<TaskRun> tasks = []
 
-    private Map<Path,Path> publishedOutputs = [:]
+    private Map<Path,Path> workflowOutputs = [:]
 
     ProvObserver(Path path, String format, Boolean overwrite, List patterns) {
         this.path = path
@@ -68,11 +68,14 @@ class ProvObserver implements TraceObserver {
     }
 
     private Renderer createRenderer(String format) {
-        if( format == 'legacy' )
-            return new LegacyRenderer()
-
         if( format == 'bco' )
             return new BcoRenderer()
+
+        if( format == 'dag' )
+            return new DagRenderer()
+
+        if( format == 'legacy' )
+            return new LegacyRenderer()
 
         throw new IllegalArgumentException("Invalid provenance format -- valid formats are ${VALID_FORMATS.join(', ')}")
     }
@@ -115,7 +118,7 @@ class ProvObserver implements TraceObserver {
         if( !match )
             return
 
-        publishedOutputs[source] = destination
+        workflowOutputs[source] = destination
     }
 
     @Override
@@ -123,7 +126,7 @@ class ProvObserver implements TraceObserver {
         if( !session.isSuccess() )
             return
 
-        renderer.render(session, tasks, publishedOutputs, path)
+        renderer.render(session, tasks, workflowOutputs, path)
     }
 
 }

--- a/plugins/nf-prov/src/resources/nextflow/prov/mermaid.dag.template.html
+++ b/plugins/nf-prov/src/resources/nextflow/prov/mermaid.dag.template.html
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright 2013-2023, Seqera Labs
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+</head>
+<body>
+<pre class="mermaid" style="text-align: center;">
+REPLACE_WITH_NETWORK_DATA
+</pre>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Render the task graph as an HTML document, originally developed in https://github.com/nextflow-io/nextflow/pull/3802

@samuell I was originally going to add your visualizer script, but then I realized we could just render the DAG directly in the plugin! I already wrote the code in a Nextflow PR but i think it fits better here. The task DAG is a sort of provenance report after all... anyway, want to give it a try and let me know if it can be improved at all?

Here is an example diagram for an rnaseq-nf run:

```html
<html>
<head>
<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
</head>
<body>
<pre class="mermaid" style="text-align: center;">
flowchart TD
    subgraph " "
    in0["ggal_gut_1.fq"]
    click in0 href "https://github.com/nextflow-io/rnaseq-nf/tree/d910312506c6539365ed70aacda5068dea9152dd/data/ggal/ggal_gut_1.fq" _blank
    in1["ggal_gut_2.fq"]
    click in1 href "https://github.com/nextflow-io/rnaseq-nf/tree/d910312506c6539365ed70aacda5068dea9152dd/data/ggal/ggal_gut_2.fq" _blank
    in2["ggal_1_48850000_49020000.Ggal71.500bpflank.fa"]
    click in2 href "https://github.com/nextflow-io/rnaseq-nf/tree/d910312506c6539365ed70aacda5068dea9152dd/data/ggal/ggal_1_48850000_49020000.Ggal71.500bpflank.fa" _blank
    in3["multiqc"]
    click in3 href "https://github.com/nextflow-io/rnaseq-nf/tree/d910312506c6539365ed70aacda5068dea9152dd/multiqc" _blank
    end
    subgraph RNASEQ
    t0(["FASTQC (FASTQC on ggal_gut)"])
    t1(["INDEX (ggal_1_48850000_49020000)"])
    t2(["QUANT (ggal_gut)"])
    end
    t3(["MULTIQC"])
    in0 --> t0
    in1 --> t0
    in2 --> t1
    t1 -->|index| t2
    in0 --> t2
    in1 --> t2
    t2 -->|ggal_gut| t3
    t0 -->|fastqc_ggal_gut_logs| t3
    in3 --> t3
    t3 --> out0
    subgraph " "
    out0[multiqc_report.html]
    end
</pre>
<script type="module">
  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
  mermaid.initialize({ startOnLoad: true });
</script>
</body>
</html>
```