### PR TITLE
Support multiple formats in the same run

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ plugins {
 }
 
 prov {
-    enabled = true
-    overwrite = true
-    file = "${params.outdir}/manifest.json"
+  enabled = true
+  formats {
+    legacy {
+      file = 'manifest.json'
+      overwrite = true
+    }
+  }
 }
 ```
 
@@ -24,31 +28,42 @@ Finally, run your Nextflow pipeline. You do not need to modify your pipeline scr
 
 ## Configuration
 
+*The `file`, `format`, and `overwrite` options have been deprecated since version 1.2.0. Use `formats` instead.*
+
 The following options are available:
 
 `prov.enabled`
 
 Create the provenance report (default: `true` if plugin is loaded).
 
-`prov.file`
+`prov.formats`
 
-The path of the provenance report (default: `manifest.json`).
+Configuration scope for the desired output formats. The following formats are available:
 
-`prov.format`
-
-The report format. The following formats are available:
-
-- `bco`: Render a [BioCompute Object](https://biocomputeobject.org/).
+- `bco`: Render a [BioCompute Object](https://biocomputeobject.org/). Supports the `file` and `overwrite` options.
 
   Visit the [BCO User Guide](https://docs.biocomputeobject.org/user_guide/) to learn more about this format and how to extend it with information that isn't available to Nextflow.
 
-- `dag`: Render the task graph as a Mermaid diagram embedded in an HTML document.
+- `dag`: Render the task graph as a Mermaid diagram embedded in an HTML document. Supports the `file` and `overwrite` options.
 
-- `legacy`: Render the legacy format originally defined in this plugin (default).
+- `legacy`: Render the legacy format originally defined in this plugin (default). Supports the `file` and `overwrite` options.
 
-`prov.overwrite`
+Any number of formats can be specified, for example:
 
-Overwrite any existing provenance report with the same name (default: `false`).
+```groovy
+prov {
+  formats {
+    bco {
+      file = 'bco.json'
+      overwrite = true
+    }
+    legacy {
+      file = 'manifest.json'
+      overwrite = true
+    }
+  }
+}
+```
 
 `prov.patterns`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,18 @@ params {
 }
 
 prov {
-    overwrite = true
-    file = "${params.outdir}/bco.json"
-    format = 'bco'
+    formats {
+        bco {
+            file = "${params.outdir}/bco.json"
+            overwrite = true
+        }
+        dag {
+            file = "${params.outdir}/dag.html"
+            overwrite = true
+        }
+        legacy {
+            file = "${params.outdir}/manifest.json"
+            overwrite = true
+        }
+    }
 }

--- a/plugins/nf-prov/src/main/nextflow/prov/BcoRenderer.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/BcoRenderer.groovy
@@ -35,11 +35,22 @@ import nextflow.util.CacheHelper
 @CompileStatic
 class BcoRenderer implements Renderer {
 
+    private Path path
+
+    private boolean overwrite
+
     @Delegate
     private PathNormalizer normalizer
 
+    BcoRenderer(Map opts) {
+        path = opts.file as Path
+        overwrite = opts.overwrite as Boolean
+
+        ProvHelper.checkFileOverwrite(path, overwrite)
+    }
+
     @Override
-    void render(Session session, Set<TaskRun> tasks, Map<Path,Path> workflowOutputs, Path path) {
+    void render(Session session, Set<TaskRun> tasks, Map<Path,Path> workflowOutputs) {
         // get workflow inputs
         final taskLookup = ProvHelper.getTaskLookup(tasks)
         final workflowInputs = ProvHelper.getWorkflowInputs(tasks, taskLookup)

--- a/plugins/nf-prov/src/main/nextflow/prov/DagRenderer.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/DagRenderer.groovy
@@ -33,11 +33,22 @@ import nextflow.util.StringUtils
 @CompileStatic
 class DagRenderer implements Renderer {
 
+    private Path path
+
+    private boolean overwrite
+
     @Delegate
     private PathNormalizer normalizer
 
+    DagRenderer(Map opts) {
+        path = opts.file as Path
+        overwrite = opts.overwrite as Boolean
+
+        ProvHelper.checkFileOverwrite(path, overwrite)
+    }
+
     @Override
-    void render(Session session, Set<TaskRun> tasks, Map<Path,Path> workflowOutputs, Path path) {
+    void render(Session session, Set<TaskRun> tasks, Map<Path,Path> workflowOutputs) {
         // get workflow metadata
         final metadata = session.workflowMetadata
         this.normalizer = new PathNormalizer(metadata)

--- a/plugins/nf-prov/src/main/nextflow/prov/LegacyRenderer.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/LegacyRenderer.groovy
@@ -32,6 +32,17 @@ import nextflow.processor.TaskRun
 @CompileStatic
 class LegacyRenderer implements Renderer {
 
+    private Path path
+
+    private boolean overwrite
+
+    LegacyRenderer(Map opts) {
+        path = opts.file as Path
+        overwrite = opts.overwrite as Boolean
+
+        ProvHelper.checkFileOverwrite(path, overwrite)
+    }
+
     private static def jsonify(root) {
         if ( root instanceof Map )
             root.collectEntries( (k, v) -> [k, jsonify(v)] )
@@ -79,7 +90,7 @@ class LegacyRenderer implements Renderer {
     }
 
     @Override
-    void render(Session session, Set<TaskRun> tasks, Map<Path,Path> outputs, Path path) {
+    void render(Session session, Set<TaskRun> tasks, Map<Path,Path> outputs) {
         // generate task manifest
         def tasksMap = tasks.inject([:]) { accum, task ->
             accum[task.id] = renderTask(task)

--- a/plugins/nf-prov/src/main/nextflow/prov/ProvHelper.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/ProvHelper.groovy
@@ -19,6 +19,8 @@ package nextflow.prov
 import java.nio.file.Path
 
 import groovy.transform.CompileStatic
+import nextflow.exception.AbortOperationException
+import nextflow.file.FileHelper
 import nextflow.processor.TaskRun
 import nextflow.script.params.FileOutParam
 
@@ -29,6 +31,23 @@ import nextflow.script.params.FileOutParam
  */
 @CompileStatic
 class ProvHelper {
+
+    /**
+     * Check whether a file already exists and throw an
+     * error if it cannot be overwritten.
+     *
+     * @param path
+     * @param overwrite
+     */
+    static void checkFileOverwrite(Path path, boolean overwrite) {
+        final attrs = FileHelper.readAttributes(path)
+        if( attrs ) {
+            if( overwrite && (attrs.isDirectory() || !path.delete()) )
+                throw new AbortOperationException("Unable to overwrite existing provenance file: ${path.toUriString()}")
+            else if( !overwrite )
+                throw new AbortOperationException("Provenance file already exists: ${path.toUriString()}")
+        }
+    }
 
     /**
      * Get the list of output files for a task.

--- a/plugins/nf-prov/src/main/nextflow/prov/Renderer.groovy
+++ b/plugins/nf-prov/src/main/nextflow/prov/Renderer.groovy
@@ -27,6 +27,6 @@ import nextflow.processor.TaskRun
  */
 interface Renderer {
 
-    abstract void render(Session session, Set<TaskRun> tasks, Map<Path,Path> outputs, Path path)
+    abstract void render(Session session, Set<TaskRun> tasks, Map<Path,Path> outputs)
 
 }

--- a/plugins/nf-prov/src/test/nextflow/prov/ProvObserverFactoryTest.groovy
+++ b/plugins/nf-prov/src/test/nextflow/prov/ProvObserverFactoryTest.groovy
@@ -27,7 +27,18 @@ class ProvObserverFactoryTest extends Specification {
 
     def 'should return observer' () {
         when:
-        def session = Spy(Session)
+        def config = [
+            prov: [
+                formats: [
+                    legacy: [
+                        file: 'manifest.json'
+                    ]
+                ]
+            ]
+        ]
+        def session = Spy(Session) {
+            getConfig() >> config
+        }
         def result = new ProvObserverFactory().create(session)
         then:
         result.size()==1


### PR DESCRIPTION
Close #9 

Extends the configuration so that multiple output formats can be specified.

For backwards compatibility, if `format` is specified then `format`, `file`, and `overwrite` will be used with a deprecation warning.

If no format is specified, an error is thrown rather than using a default.

Example configuration:
```groovy
prov {
    formats {
        bco {
            file = "${params.outdir}/bco.json"
            overwrite = true
        }
        dag {
            file = "${params.outdir}/dag.html"
            overwrite = true
        }
        legacy {
            file = "${params.outdir}/manifest.json"
            overwrite = true
        }
    }
}
```