### PR TITLE
Increased limits for text size and number of edges to Number.MAX_SAFE…

### DIFF
--- a/plugins/nf-prov/src/resources/nextflow/prov/mermaid.dag.template.html
+++ b/plugins/nf-prov/src/resources/nextflow/prov/mermaid.dag.template.html
@@ -23,7 +23,7 @@ REPLACE_WITH_NETWORK_DATA
 </pre>
 <script type="module">
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-  mermaid.initialize({ startOnLoad: true });
+  mermaid.initialize({ startOnLoad: true, maxTextSize: Number.MAX_SAFE_INTEGER, maxEdges: Number.MAX_SAFE_INTEGER });
 </script>
 </body>
 </html>


### PR DESCRIPTION
…_INTEGER since the previous limits were not enough for displaying some provenance graphs (e.g. for nf-core/rnaseq)