### PR TITLE
Add missing `file` field to example config in WRROC.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ prov {
       file = 'bco.json'
       overwrite = true
     }
-    legacy {
-      file = 'manifest.json'
+    wrroc {
+      file = 'ro-crate-metadata.json'
       overwrite = true
     }
   }

--- a/docs/BCO.md
+++ b/docs/BCO.md
@@ -26,6 +26,8 @@ Here is an example config based on the BCO User Guide:
 prov {
   formats {
     bco {
+      file = 'bco.json'
+      overwrite = true
       provenance_domain {
         review = [
           [

--- a/docs/WRROC.md
+++ b/docs/WRROC.md
@@ -28,6 +28,8 @@ Here is an example config:
 prov {
     formats {
         wrroc {
+            file = "ro-crate-metadata.json"
+            overwrite = true
             agent {
                 name = "John Doe"
                 orcid = "https://orcid.org/0000-0000-0000-0000"


### PR DESCRIPTION
If this field is missing a rather cryptic error message is thrown when starting a workflow
`ERROR ~ Cannot invoke method toAbsolutePath() on null object` 