### PR TITLE
Declare config options with ConfigScope

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [17]
-        nextflow_version: ['24.10']
+        nextflow_version: ['25.04']
 
     steps:
       - name: Environment
@@ -51,4 +51,4 @@ jobs:
         run: make install
 
       - name: Test
-        run: nextflow run nf-prov-test/ -plugins nf-prov@1.4.0
+        run: nextflow run nf-prov-test/ -plugins nf-prov@1.5.0

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 version = '1.5.0'
 
 nextflowPlugin {
-    nextflowVersion = '25.02.0-edge'
+    nextflowVersion = '25.02.1-edge'
 
     provider = 'nextflow'
     className = 'nextflow.prov.ProvPlugin'
@@ -25,4 +25,9 @@ nextflowPlugin {
             indexUrl = 'https://github.com/nextflow-io/plugins/blob/main/plugins.json'
         }
     }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 version = '1.5.0'
 
 nextflowPlugin {
-    nextflowVersion = '25.02.1-edge'
+    nextflowVersion = '25.02.2-edge'
 
     provider = 'nextflow'
     className = 'nextflow.prov.ProvPlugin'
@@ -25,9 +25,4 @@ nextflowPlugin {
             indexUrl = 'https://github.com/nextflow-io/plugins/blob/main/plugins.json'
         }
     }
-}
-
-repositories {
-    mavenLocal()
-    mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,15 @@ plugins {
     id 'io.nextflow.nextflow-plugin' version '0.0.1-alpha2'
 }
 
-version = '1.4.0'
+version = '1.5.0'
 
 nextflowPlugin {
-    nextflowVersion = '24.10.0'
+    nextflowVersion = '25.02.0-edge'
 
     provider = 'nextflow'
     className = 'nextflow.prov.ProvPlugin'
     extensionPoints = [
+        'nextflow.prov.ProvConfig',
         'nextflow.prov.ProvObserverFactory'
     ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 
 plugins {
-    id 'io.nextflow.nextflow-plugin' version '0.0.1-alpha2'
+    id 'io.nextflow.nextflow-plugin' version '0.0.1-alpha3'
 }
 
 version = '1.5.0'
 
 nextflowPlugin {
-    nextflowVersion = '25.03.0-edge'
+    nextflowVersion = '25.04.0'
 
     provider = 'nextflow'
     className = 'nextflow.prov.ProvPlugin'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 version = '1.5.0'
 
 nextflowPlugin {
-    nextflowVersion = '25.02.2-edge'
+    nextflowVersion = '25.03.0-edge'
 
     provider = 'nextflow'
     className = 'nextflow.prov.ProvPlugin'

--- a/src/main/groovy/nextflow/prov/ProvConfig.groovy
+++ b/src/main/groovy/nextflow/prov/ProvConfig.groovy
@@ -31,7 +31,6 @@ class ProvConfig implements ConfigScope {
     @Description('Create the provenance report (default: `true` if plugin is loaded).')
     boolean enabled
 
-    @ConfigOption
     @Description('Configuration scope for the desired output formats.')
     ProvFormatsConfig formats
 }

--- a/src/main/groovy/nextflow/prov/ProvConfig.groovy
+++ b/src/main/groovy/nextflow/prov/ProvConfig.groovy
@@ -113,4 +113,10 @@ class ProvWrrocConfig implements ConfigScope {
         When `true` overwrites any existing Workflow Run RO-Crate with the same name.
         ''')
     boolean overwrite
+
+    @ConfigOption
+    @Description('''
+        The license for the Workflow Run RO-Crate.
+        ''')
+    String license
 }

--- a/src/main/groovy/nextflow/prov/ProvConfig.groovy
+++ b/src/main/groovy/nextflow/prov/ProvConfig.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.prov
+
+import nextflow.config.schema.ConfigOption
+import nextflow.config.schema.ConfigScope
+import nextflow.config.schema.ScopeName
+import nextflow.script.dsl.Description
+
+@ScopeName('prov')
+@Description('''
+    The `prov` scope allows you to configure the `nf-prov` plugin.
+''')
+class ProvConfig implements ConfigScope {
+
+    @ConfigOption
+    @Description('Create the provenance report (default: `true` if plugin is loaded).')
+    boolean enabled
+
+    @ConfigOption
+    @Description('Configuration scope for the desired output formats.')
+    ProvFormatsConfig formats
+}
+
+
+class ProvFormatsConfig implements ConfigScope {
+
+    @Description('Configuration scope for the BCO output format.')
+    ProvBcoConfig bco
+
+    @Description('Configuration scope for the DAG output format.')
+    ProvDagConfig dag
+
+    @Description('Configuration scope for the legacy output format.')
+    ProvLegacyConfig legacy
+
+    @Description('Configuration scope for the WRROC output format.')
+    ProvWrrocConfig wrroc
+}
+
+
+class ProvBcoConfig implements ConfigScope {
+
+    @ConfigOption
+    @Description('''
+        The file name of the BCO manifest.
+        ''')
+    String file
+
+    @ConfigOption
+    @Description('''
+        When `true` overwrites any existing BCO manifest with the same name.
+        ''')
+    boolean overwrite
+}
+
+
+class ProvDagConfig implements ConfigScope {
+
+    @ConfigOption
+    @Description('''
+        The file name of the DAG diagram.
+        ''')
+    String file
+
+    @ConfigOption
+    @Description('''
+        When `true` overwrites any existing DAG diagram with the same name.
+        ''')
+    boolean overwrite
+}
+
+
+class ProvLegacyConfig implements ConfigScope {
+
+    @ConfigOption
+    @Description('''
+        The file name of the legacy manifest.
+        ''')
+    String file
+
+    @ConfigOption
+    @Description('''
+        When `true` overwrites any existing legacy manifest with the same name.
+        ''')
+    boolean overwrite
+}
+
+
+class ProvWrrocConfig implements ConfigScope {
+
+    @ConfigOption
+    @Description('''
+        The file name of the Workflow Run RO-Crate.
+        ''')
+    String file
+
+    @ConfigOption
+    @Description('''
+        When `true` overwrites any existing Workflow Run RO-Crate with the same name.
+        ''')
+    boolean overwrite
+}


### PR DESCRIPTION
This PR adds a ConfigScope implementation for nf-prov config options.

```bash
# build and install nf-prov locally
make install

# test the plugin
NXF_SYNTAX_PARSER=v2 NXF_VER=25.03.0-edge nextflow config nf-prov-test/
```

Also need to pin the plugin version in the `nf-prov-test` config:
```groovy
plugins {
    id 'nf-prov@1.5.0'
}
```