### PR TITLE
Replace staged input file with original URL

### DIFF
--- a/src/main/groovy/nextflow/prov/renderers/BcoRenderer.groovy
+++ b/src/main/groovy/nextflow/prov/renderers/BcoRenderer.groovy
@@ -112,7 +112,7 @@ class BcoRenderer implements Renderer {
                     "step_number": task.id,
                     "name": task.hash.toString(),
                     "description": task.name,
-                    "input_list": task.getInputFilesMap().collect { name, source -> [
+                    "input_list": ProvHelper.getTaskInputs(task).collect { name, source -> [
                         "uri": normalizePath(source)
                     ] },
                     "output_list": ProvHelper.getTaskOutputs(task).collect { source -> [

--- a/src/main/groovy/nextflow/prov/renderers/DagRenderer.groovy
+++ b/src/main/groovy/nextflow/prov/renderers/DagRenderer.groovy
@@ -67,7 +67,7 @@ class DagRenderer implements Renderer {
     private Map<TaskRun,Vertex> getVertices(Set<TaskRun> tasks) {
         Map<TaskRun,Vertex> result = [:]
         for( final task : tasks ) {
-            final inputs = task.getInputFilesMap()
+            final inputs = ProvHelper.getTaskInputs(task)
             final outputs = ProvHelper.getTaskOutputs(task)
 
             result[task] = new Vertex(result.size(), task.name, inputs, outputs)


### PR DESCRIPTION
This PR uses https://github.com/nextflow-io/nextflow/pull/5911 to trace staged input files to their original URL.

Test:
```bash
# initial run
rm -rf ~/.nextflow/plugins/nf-prov-1.4.0
nextflow run nf-prov-test/

# build nf-prov
(cd ../nextflow ; ./gradlew :nextflow:publishToMavenLocal)
make install

# resumed run (should fully resume)
../nextflow/build/releases/nextflow-25.03.1-edge-dist run nf-prov-test/ -plugins nf-prov@1.4.0 -resume
```

Before:
```json
{
    "name": "de11525869ad90b98a2d376c4c30a545",
    "description": "WC_SAMPLE (1)",
    "input_list": [
        {
            "uri": "work/stage-5170692d-7ce4-44da-877a-8ed0fc6a9f29/b9/75a58cde91580a079c4fca5d42d70e/read2.fq.gz"
        },
        {
            "uri": "work/stage-5170692d-7ce4-44da-877a-8ed0fc6a9f29/4d/58a16d7add20fdcddcff6bdeea01d5/read1.fq.gz"
        }
    ],
}
```

After:
```json
{
    "name": "de11525869ad90b98a2d376c4c30a545",
    "description": "WC_SAMPLE (1)",
    "input_list": [
        {
            "uri": "https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/denbi-mg-course/read2.fq.gz"
        },
        {
            "uri": "https://openstack.cebitec.uni-bielefeld.de:8080/swift/v1/denbi-mg-course/read1.fq.gz"
        }
    ],
}
```