### PR TITLE
Metadata config

### DIFF
--- a/nf-prov-test/nextflow.config
+++ b/nf-prov-test/nextflow.config
@@ -7,13 +7,12 @@ params {
     outdir = 'results'
 }
 
-metadata {
-    study = "Nextflow Hackathon"
-}
-
 outputDir = params.outdir
 
 prov {
+    metadata {
+        study = "Nextflow Hackathon"
+    }
     formats {
         bco {
             file = "${params.outdir}/bco.json"

--- a/nf-prov-test/nextflow.config
+++ b/nf-prov-test/nextflow.config
@@ -7,6 +7,10 @@ params {
     outdir = 'results'
 }
 
+metadata {
+    study = "Nextflow Hackathon"
+}
+
 outputDir = params.outdir
 
 prov {

--- a/src/main/groovy/nextflow/prov/ProvConfig.groovy
+++ b/src/main/groovy/nextflow/prov/ProvConfig.groovy
@@ -46,6 +46,11 @@ class ProvConfig implements ConfigScope {
     ''')
     final List<String> patterns
 
+    @Description('''
+        User configured metadata for passing metadata upstream of pipeline execution.
+    ''')
+    final Map metadata
+
     /* required by extension point -- do not remove */
     ProvConfig() {}
 
@@ -157,4 +162,6 @@ class ProvWrrocConfig implements ConfigScope {
         overwrite = opts.overwrite as boolean
         license = opts.license
     }
+
+
 }

--- a/src/main/groovy/nextflow/prov/renderers/WrrocRenderer.groovy
+++ b/src/main/groovy/nextflow/prov/renderers/WrrocRenderer.groovy
@@ -99,6 +99,9 @@ class WrrocRenderer implements Renderer {
         if( organization )
             agent["affiliation"] = ["@id": organization["@id"]]
 
+        // parse metadata
+        final configMeta = session.config.navigate('prov.metadata', [:]) as Map
+
         // create manifest
         final datasetParts = []
 
@@ -542,7 +545,8 @@ class WrrocRenderer implements Renderer {
                         *asReferences(taskOutputs),
                         *asReferences(publishCreateActions),
                     ],
-                    "license"    : wrrocOpts.license
+                    "license"    : wrrocOpts.license,
+                    "configMetadata"    : configMeta
                 ]),
                 [
                     "@id"    : "https://w3id.org/ro/wfrun/process/0.1",


### PR DESCRIPTION
This PR adds a new config scope to nf-prov that allows users to pass in metadata in the nextflow.config that is written to ro-crate-manifest.json.