### PR TITLE
fix JSON schema validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the nf-prov plugin will be documented here.
 
 See [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [dev]
+
+- Omit optional BCO properties when null
+- Nest script URIs in execution domain
+
 ## [1.7.0] - 2026-01-05
 
 - Add GEXF renderer (#57)

--- a/src/main/groovy/nextflow/prov/renderers/BcoRenderer.groovy
+++ b/src/main/groovy/nextflow/prov/renderers/BcoRenderer.groovy
@@ -100,7 +100,7 @@ class BcoRenderer implements Renderer {
                 "created": dateCreated,
                 "modified": dateCreated,
                 "contributors": contributors,
-                "license": manifest.license
+                "license": manifest.license ?: ""
             ],
             "usability_domain": usability,
             "extension_domain": [],
@@ -198,7 +198,27 @@ class BcoRenderer implements Renderer {
         bco.etag = etag.toString()
 
         // render BCO manifest to JSON file
-        path.text = JsonOutput.prettyPrint(JsonOutput.toJson(bco))
+        path.text = JsonOutput.prettyPrint(JsonOutput.toJson(removeNulls(bco)))
+    }
+
+    private static Object removeNulls(Object value) {
+        if (value instanceof Map) {
+            return ((Map) value).collectEntries { k, v ->
+                if (v instanceof Map || v instanceof List) {
+                    [k, removeNulls(v)]
+                } else if (v != null) {
+                    [k, v]
+                } else {
+                    [:]
+                }
+            }
+        } else if (value instanceof List) {
+            return ((List) value).collect { v ->
+                removeNulls(v)
+            }.findAll { it != null }
+        } else {
+            return value
+        }
     }
 
     private List getContributors(Manifest manifest) {

--- a/src/main/groovy/nextflow/prov/renderers/BcoRenderer.groovy
+++ b/src/main/groovy/nextflow/prov/renderers/BcoRenderer.groovy
@@ -121,7 +121,13 @@ class BcoRenderer implements Renderer {
                 ] },
             ],
             "execution_domain": [
-                "script": [ normalizePath(metadata.scriptFile) ],
+                "script": [
+                    [
+                        "uri": [
+                            "uri": normalizePath(metadata.scriptFile)
+                        ]
+                    ]
+                ],
                 "script_driver": "nextflow",
                 "software_prerequisites": [
                     [


### PR DESCRIPTION
Fixes #58. I have written a generic function `removeNulls()`, which removes all null entries, unless they are mandatory (such as `license`). With this fix in place, the BCO JSON schema validation succeeds.