### PR TITLE
Record command-line in BCO and WRROC files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the nf-prov plugin will be documented here.
 
 See [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [dev]
+
+- Add `recordCommandLine` option for BCO and WRROC formats
+
 ## [1.7.0] - 2026-01-05
 
 - Add GEXF renderer (#57)

--- a/src/main/groovy/nextflow/prov/ProvConfig.groovy
+++ b/src/main/groovy/nextflow/prov/ProvConfig.groovy
@@ -108,9 +108,16 @@ class ProvBcoConfig implements ConfigScope {
     ''')
     final boolean overwrite
 
+    @ConfigOption
+    @Description('''
+        When `true` records the execution command-line in the usability domain (default: `false`).
+    ''')
+    final boolean recordCommandLine
+
     ProvBcoConfig(Map opts) {
         file = opts.file
         overwrite = opts.overwrite as boolean
+        recordCommandLine = opts.recordCommandLine as boolean
     }
 }
 
@@ -180,9 +187,16 @@ class ProvWrrocConfig implements ConfigScope {
     ''')
     final String license
 
+    @ConfigOption
+    @Description('''
+        When `true` records the execution command-line in the action description (default: `false`).
+    ''')
+    final boolean recordCommandLine
+
     ProvWrrocConfig(Map opts) {
         file = opts.file
         overwrite = opts.overwrite as boolean
         license = opts.license
+        recordCommandLine = opts.recordCommandLine as boolean
     }
 }

--- a/src/main/groovy/nextflow/prov/renderers/BcoRenderer.groovy
+++ b/src/main/groovy/nextflow/prov/renderers/BcoRenderer.groovy
@@ -46,12 +46,15 @@ class BcoRenderer implements Renderer {
 
     private boolean overwrite
 
+    private boolean recordCommandLine
+
     @Delegate
     private PathNormalizer normalizer
 
     BcoRenderer(ProvBcoConfig config) {
         path = (config.file as Path).complete()
         overwrite = config.overwrite
+        recordCommandLine = config.recordCommandLine
 
         ProvHelper.checkFileOverwrite(path, overwrite)
     }
@@ -84,6 +87,10 @@ class BcoRenderer implements Renderer {
         final xref                    = config.navigate('prov.formats.bco.description_domain.xref', []) as List<Map<String,?>>
         final external_data_endpoints = config.navigate('prov.formats.bco.execution_domain.external_data_endpoints', []) as List<Map<String,String>>
         final environment_variables   = config.navigate('prov.formats.bco.execution_domain.environment_variables', []) as List<String>
+
+        if( recordCommandLine && metadata.commandLine ) {
+            usability.add(0, "Command-line: " + metadata.commandLine)
+        }
 
         // create BCO manifest
         final bco = [

--- a/src/main/groovy/nextflow/prov/renderers/WrrocRenderer.groovy
+++ b/src/main/groovy/nextflow/prov/renderers/WrrocRenderer.groovy
@@ -57,6 +57,8 @@ class WrrocRenderer implements Renderer {
 
     private boolean overwrite
 
+    private boolean recordCommandLine
+
     @Delegate
     private PathNormalizer normalizer
 
@@ -66,6 +68,7 @@ class WrrocRenderer implements Renderer {
     WrrocRenderer(ProvWrrocConfig config) {
         path = (config.file as Path).complete()
         overwrite = config.overwrite
+        recordCommandLine = config.recordCommandLine
 
         ProvHelper.checkFileOverwrite(path, overwrite)
     }
@@ -617,11 +620,12 @@ class WrrocRenderer implements Renderer {
                     "startTime" : dateStarted,
                     "endTime"   : dateCompleted
                 ],
-                [
+                withoutNulls([
                     "@id"       : "#${session.uniqueId}",
                     "@type"     : "CreateAction",
                     "agent"     : agent ? ["@id": agent["@id"]] : null,
                     "name"      : "Nextflow workflow run ${session.uniqueId}",
+                    "description": recordCommandLine && metadata.commandLine ? "Command-line: " + metadata.commandLine : null,
                     "startTime" : dateStarted,
                     "endTime"   : dateCompleted,
                     "instrument": ["@id": mainScriptId],
@@ -630,7 +634,7 @@ class WrrocRenderer implements Renderer {
                         *asReferences(inputFiles),
                     ],
                     "result"    : asReferences(outputFiles)
-                ],
+                ]),
                 agent,
                 organization,
                 *contactPoints,


### PR DESCRIPTION
Following up on my question in #58, this PR introduces an optional configuration flag, `recordCommandLine`, for both the BCO and WRROC provenance output formats. By default, it is off, ensuring the exact same behavior of the plugin as usual. When enabled, the plugin records the exact command-line invocation used to launch the Nextflow workflow in the generated provenance metadata.

Configuration example:

```
prov {
    formats {
        bco {
            recordCommandLine = true
        }
        wrroc {
            recordCommandLine = true
        }
    }
}
```

The command-line is recorded in the `usability_domain` of the BCO object. The IEEE-2791 schema specifies `usability_domain` as a list of free-text strings intended to guide users on how to understand, execute, or reproduce the computational object. Placing the launch command here provides clear, human-readable execution context without violating strict schema constraints.

The WRROC object records the info in the `description` of the main `CreateAction`. This is where the specification explicitly recommends putting details on the execution of the pipeline.

Let me know what you think about this suggestion.